### PR TITLE
Add WebSocket URL templating

### DIFF
--- a/core/lib/engine_ws.js
+++ b/core/lib/engine_ws.js
@@ -98,7 +98,10 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
       ee.emit('started');
 
-      let ws = new WebSocket(config.target, options);
+      const wsUrl = template(config.target, initialContext);
+
+      let ws = new WebSocket(wsUrl, options);
+
       ws.on('open', function() {
         initialContext.ws = ws;
         return callback(null, initialContext);


### PR DESCRIPTION
When using ws engine now it is possible to use templating in the target url parameter